### PR TITLE
[SRE-229] prometheus config: increase max_samples_per_send. Lower scrape_interval back to 5s

### DIFF
--- a/config-generator/src/generate.js
+++ b/config-generator/src/generate.js
@@ -162,15 +162,15 @@ generate()
 function prometheusConfig(params) {
   let obj = {
     global: {
-      scrape_interval: '30s',
+      scrape_interval: '5s',
       scrape_timeout: '5s',
-      evaluation_interval: '30s',
+      evaluation_interval: '5s',
       external_labels: {
         region: params.region
       },
     },
     queue_config: {
-      max_samples_per_send: 4000,
+      max_samples_per_send: 10000,
       batch_send_deadline: '30s'
     },
     scrape_configs: [],
@@ -325,7 +325,7 @@ function prometheusConfig(params) {
 function getPromKubeJobs(namespaces, promKubeScrape) {
   return [{
       job_name: 'kubernetes-apiservers',
-      scrape_interval: '30s',
+      scrape_interval: '5s',
       scrape_timeout: '5s',
       metrics_path: '/metrics',
       scheme: 'https',
@@ -355,7 +355,7 @@ function getPromKubeJobs(namespaces, promKubeScrape) {
     },
     {
       job_name: 'kubernetes-nodes',
-      scrape_interval: '30s',
+      scrape_interval: '5s',
       scrape_timeout: '5s',
       metrics_path: '/metrics',
       scheme: 'https',
@@ -396,7 +396,7 @@ function getPromKubeJobs(namespaces, promKubeScrape) {
     },
     {
       job_name: 'kubernetes-pods',
-      scrape_interval: '30s',
+      scrape_interval: '5s',
       scrape_timeout: '5s',
       metrics_path: '/metrics',
       scheme: 'http',
@@ -463,7 +463,7 @@ function getPromKubeJobs(namespaces, promKubeScrape) {
     },
     {
       job_name: 'kubernetes-cadvisor',
-      scrape_interval: '30s',
+      scrape_interval: '5s',
       scrape_timeout: '5s',
       metrics_path: '/metrics',
       scheme: 'https',
@@ -504,7 +504,7 @@ function getPromKubeJobs(namespaces, promKubeScrape) {
     },
     {
       job_name: 'kubernetes-service-endpoints',
-      scrape_interval: '30s',
+      scrape_interval: '5s',
       scrape_timeout: '5s',
       metrics_path: '/metrics',
       scheme: 'http',

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,14 +1,14 @@
 global:
-  scrape_interval: 30s
+  scrape_interval: 5s
   scrape_timeout: 5s
-  evaluation_interval: 30s
+  evaluation_interval: 5s
 scrape_configs:
   - job_name: grafana-image-rendering-service
     static_configs:
       - targets:
           - localhost:8081
   - job_name: kubernetes-apiservers
-    scrape_interval: 30s
+    scrape_interval: 5s
     scrape_timeout: 5s
     metrics_path: /metrics
     scheme: https
@@ -34,7 +34,7 @@ scrape_configs:
         replacement: $1
         action: keep
   - job_name: kubernetes-nodes
-    scrape_interval: 30s
+    scrape_interval: 5s
     scrape_timeout: 5s
     metrics_path: /metrics
     scheme: https
@@ -65,7 +65,7 @@ scrape_configs:
         replacement: /api/v1/nodes/${1}/proxy/metrics
         action: replace
   - job_name: kubernetes-pods
-    scrape_interval: 30s
+    scrape_interval: 5s
     scrape_timeout: 5s
     metrics_path: /metrics
     scheme: http
@@ -111,7 +111,7 @@ scrape_configs:
         replacement: $1
         action: replace
   - job_name: kubernetes-cadvisor
-    scrape_interval: 30s
+    scrape_interval: 5s
     scrape_timeout: 5s
     metrics_path: /metrics
     scheme: https
@@ -142,7 +142,7 @@ scrape_configs:
         replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
         action: replace
   - job_name: kubernetes-service-endpoints
-    scrape_interval: 30s
+    scrape_interval: 5s
     scrape_timeout: 5s
     metrics_path: /metrics
     scheme: http


### PR DESCRIPTION
[Discord](https://discord.com/channels/423160867534929930/1102968315137228900/1194987181463322665)

30s interval is probably causing `livepeer_versions` metric to be missed during subsequent `/metrics` endpoint scrapes