### PR TITLE
rollback grafana from 10.3.1 to 10.2.3 because of log volume issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ARG	GRAFANA_ENV
 
 COPY	./grafana/${GRAFANA_ENV}/	/grafana
 
-FROM	grafana/grafana-oss:10.3.1	AS	grafana
+FROM	grafana/grafana-oss:10.2.3	AS	grafana
 
 LABEL	maintainer="Amritanshu Varshney <amritanshu+github@livepeer.org>"
 


### PR DESCRIPTION
https://github.com/grafana/grafana/blob/main/CHANGELOG.md mentions adding:
> Loki: Drop all errors in volume requests. #79686, @svennergr https://github.com/grafana/grafana/pull/79686

This is probably causing log volume queries errors