### PR TITLE
Add flag to disable prometheus from starting in the supervisord config

### DIFF
--- a/config-generator/src/generate.js
+++ b/config-generator/src/generate.js
@@ -111,6 +111,11 @@ function generate() {
         default: "",
         type: "string",
       },
+      "prometheus-disabled": {
+        describe: "Disable prometheus server during deployment",
+        default: false,
+        type: "boolean",
+      },
       "cadvisor-port": {
         describe: "[docker compose mode only] the port defined for cadvisor",
         default: 8080,

--- a/config-generator/src/supervisord.js
+++ b/config-generator/src/supervisord.js
@@ -9,7 +9,7 @@ function generate(params, defaults = "/etc/supervisor.d/supervisord.ini") {
     console.log("ini obj: ", obj);
 
     // prometheus args
-    if (params) {
+    if (params && !params["prometheus-disabled"]) {
         obj[
             "program:prometheus"
         ].command = `/usr/local/bin/prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=${


### PR DESCRIPTION
Needed to migrate to official grafana and vm-agent charts.